### PR TITLE
Fix copyAllArtifactsAndStashes again and avoid 404 stacktrace when trying to delete non-existing folder

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManager.java
@@ -71,7 +71,12 @@ public class ArtifactoryArtifactManager extends ArtifactManager implements Stash
         ArtifactoryClient client = buildArtifactoryClient();
         LOGGER.trace(String.format("Deleting %s...", virtualPath));
         try {
-            client.deleteArtifact(virtualPath);
+            if (client.isFile(virtualPath) || client.isFolder(virtualPath)) {
+                client.deleteArtifact(virtualPath);
+            } else {
+                LOGGER.debug(String.format("No file or folder found at %s", virtualPath));
+                return false;
+            }
         } catch (Exception e) {
             LOGGER.error(String.format("Failed to delete %s", virtualPath), e);
             return false;
@@ -167,13 +172,13 @@ public class ArtifactoryArtifactManager extends ArtifactManager implements Stash
                 LOGGER.debug(String.format("Copying artifacts from %s to %s", artifactPath, toArtifactPath));
                 listener.getLogger()
                         .println(String.format("Copying artifacts from %s to %s", artifactPath, toArtifactPath));
-                client.copy(stashedPath, toStashedPath);
+                client.copy(artifactPath, toArtifactPath);
             }
             if (client.isFolder(stashedPath)) {
                 listener.getLogger()
                         .println(String.format("Copying stashes from %s to %s", stashedPath, toStashedPath));
                 LOGGER.debug(String.format("Copying stashes from %s to %s", stashedPath, toStashedPath));
-                client.copy(artifactPath, toArtifactPath);
+                client.copy(stashedPath, toStashedPath);
             }
         } catch (Exception e) {
             listener.getLogger()


### PR DESCRIPTION
Fix copyAllArtifactsAndStashes again and avoid 404 stacktrace when trying to delete non-existing folder (#3)

### Testing done

Automated tests only

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
