### PR TITLE
Ensure to upload path instead of key which sometimes doesn't match

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManager.java
@@ -59,7 +59,7 @@ public class ArtifactoryArtifactManager extends ArtifactManager implements Stash
         for (Map.Entry<String, String> entry : artifacts.entrySet()) {
             String path = "artifacts/" + entry.getKey();
             String filePath = getFilePath(path);
-            files.add(new UploadFile(entry.getKey(), filePath));
+            files.add(new UploadFile(entry.getValue(), filePath));
         }
 
         workspace.act(new UploadToArtifactoryStorage(buildArtifactoryConfig(), files));


### PR DESCRIPTION
Fixes #24

Sometimes the filename and the key of the artifact are different.

Ensure to publish the file path instead of the key

```
[withMaven] artifactsPublisher - Archive artifact pom.xml under test/simple-maven-project-with-tests/1.0-SNAPSHOT/simple-maven-project-with-tests-1.0-SNAPSHOT.pom
[withMaven] artifactsPublisher - Archive artifact target/simple-maven-project-with-tests-1.0-SNAPSHOT.jar under test/simple-maven-project-with-tests/1.0-SNAPSHOT/simple-maven-project-with-tests-1.0-SNAPSHOT.jar
```

### Testing done

```groovy
pipeline {
    agent any
    stages {
        stage('Build') {
            steps {
                git url: 'https://github.com/jglick/simple-maven-project-with-tests.git'
                withMaven {
                    sh "mvn -Dmaven.test.failure.ignore=true clean package"
                }
            }
        }
    }
}

```

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
