### PR TITLE
feat: reduce api calls by reusing aql file info

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
@@ -80,19 +80,6 @@ public class BaseTest {
                 + "\""
                 + "}";
 
-        // JSON response for single artifact
-        String artifactResponse = "{"
-                + "\"created\": \"2024-03-17T13:20:19.836Z\","
-                + "\"createdBy\": \"admin\","
-                + "\"lastModified\": \"2024-03-17T13:20:19.836Z\","
-                + "\"lastUpdated\": \"2024-03-17T13:20:19.836Z\","
-                + "\"modifiedBy\": \"admin\","
-                + "\"path\": \"" + artifactBasePath + "/" + artifact + "\","
-                + "\"repo\": \"my-generic-repo\","
-                + "\"uri\": \"http://localhost:" + wmRuntimeInfo.getHttpPort() + "/artifactory" + artifactBasePath + "/"
-                + artifact + "\""
-                + "}";
-
         String stashApiResponse = "{"
                 + "\"created\": \"2024-03-17T13:20:19.836Z\","
                 + "\"createdBy\": \"admin\","
@@ -106,16 +93,16 @@ public class BaseTest {
                 + "}";
 
         // AQL response
-        String aqlResponse = "{\"results\": [{\"name\": \"" + artifact
-                + "\", \"repo\": \"my-generic-repo\", \"path\": \"" + prefix + "/" + jobName + "/1/artifacts\"}]}";
+        String aqlResponse = "{\"results\": [{"
+                + "\"name\": \"" + artifact
+                + "\", \"type\": \"file\", \"modified\": \"2024-03-17T13:20:19.836Z\", \"size\": 1234,"
+                + "\"repo\": \"my-generic-repo\", \"path\": \"" + prefix + "/" + jobName + "/1/artifacts\"}]}";
 
         // Register GET requests
 
         // Artifacts
         wireMock.register(WireMock.get(WireMock.urlEqualTo(urlEncodeParts(artifactBasePath + "/")))
                 .willReturn(WireMock.okJson(artifactsResponse)));
-        wireMock.register(WireMock.get(WireMock.urlEqualTo(urlEncodeParts(artifactBasePath + "/" + artifact)))
-                .willReturn(WireMock.okJson(artifactResponse)));
 
         // Stashes API
         wireMock.register(WireMock.get(WireMock.urlEqualTo(urlEncodeParts(stashApiBasePath + "/" + stash)))


### PR DESCRIPTION
solves #41

Uses the already present list of files (with type, size and modification date) from the AQL query to get the list of files artifacts.

### Testing done

Tested upload, listing and download with an running Artifactory instance.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
