### PR TITLE
Parallel archive artifacts

### DIFF
--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
@@ -46,8 +46,8 @@ public class BaseTest {
         WireMock wireMock = wmRuntimeInfo.getWireMock();
 
         // PUT to upload artifact
-        wireMock.register(WireMock.put(WireMock.urlMatching("/my-generic-repo/" + prefix + ".*"))
-                .willReturn(WireMock.okJson("{}")));
+        wireMock.register(
+                WireMock.put(WireMock.urlMatching("/my-generic-repo/.*")).willReturn(WireMock.okJson("{}")));
 
         // Define the base URL
         String artifactBasePath = "/api/storage/my-generic-repo/" + prefix + jobName + "/1/artifacts";

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/PipelineTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/PipelineTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import hudson.model.Label;
@@ -26,16 +27,17 @@ public class PipelineTest extends BaseTest {
 
     @Test
     public void testPipelineWithPrefix(JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-
         final String pipelineName = "testPipelineWithPrefix";
+        final String prefix = "jenkins/";
+        final String artifact = "artifact.txt";
 
-        configureConfig(jenkinsRule, wmRuntimeInfo, "jenkins/");
+        configureConfig(jenkinsRule, wmRuntimeInfo, prefix);
         String pipeline = IOUtils.toString(
                 Objects.requireNonNull(PipelineTest.class.getResourceAsStream("/pipelines/archiveController.groovy")),
                 StandardCharsets.UTF_8);
 
         // Setup wiremock stubs
-        setupWireMockStubs(pipelineName, wmRuntimeInfo, "jenkins/", "artifact.txt", "stash.tgz");
+        setupWireMockStubs(pipelineName, wmRuntimeInfo, prefix, artifact, "stash.tgz");
 
         // Run job
         WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);
@@ -45,6 +47,10 @@ public class PipelineTest extends BaseTest {
 
         // Job success
         assertThat(run1.getResult(), equalTo(hudson.model.Result.SUCCESS));
+
+        // Verify artifact was uploaded
+        WireMock.verify(WireMock.putRequestedFor(WireMock.urlEqualTo(getArtifactUrl(prefix, pipelineName, artifact)))
+                .withRequestBody(WireMock.equalTo("Hello, World!")));
 
         // Check 1 artifact
         assertThat(run1.getArtifacts(), hasSize(1));
@@ -54,15 +60,17 @@ public class PipelineTest extends BaseTest {
     public void testPipelineWithSpaces(JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         final String pipelineName = "test Pipeline With spaces";
+        final String prefix = "jenkins artifacts/";
+        final String artifact = "my artifact.txt";
 
-        configureConfig(jenkinsRule, wmRuntimeInfo, "jenkins artifacts/");
+        configureConfig(jenkinsRule, wmRuntimeInfo, prefix);
         String pipeline = IOUtils.toString(
                 Objects.requireNonNull(
                         PipelineTest.class.getResourceAsStream("/pipelines/archiveControllerWithSpaces.groovy")),
                 StandardCharsets.UTF_8);
 
         // Setup wiremock stubs
-        setupWireMockStubs(pipelineName, wmRuntimeInfo, "jenkins artifacts/", "my artifact.txt", "my stash.tgz");
+        setupWireMockStubs(pipelineName, wmRuntimeInfo, prefix, artifact, "my stash.tgz");
 
         // Run job
         WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);
@@ -72,6 +80,10 @@ public class PipelineTest extends BaseTest {
 
         // Job success
         assertThat(run1.getResult(), equalTo(hudson.model.Result.SUCCESS));
+
+        // Verify artifact was uploaded
+        WireMock.verify(WireMock.putRequestedFor(WireMock.urlEqualTo(getArtifactUrl(prefix, pipelineName, artifact)))
+                .withRequestBody(WireMock.equalTo("Hello, World!")));
 
         // Check 1 artifact
         assertThat(run1.getArtifacts(), hasSize(1));
@@ -81,14 +93,16 @@ public class PipelineTest extends BaseTest {
     public void testPipelineWithoutPrefix(JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         final String pipelineName = "testPipelineWithoutPrefix";
+        final String prefix = "";
+        final String artifact = "artifact.txt";
 
-        configureConfig(jenkinsRule, wmRuntimeInfo, "");
+        configureConfig(jenkinsRule, wmRuntimeInfo, prefix);
         String pipeline = IOUtils.toString(
                 Objects.requireNonNull(PipelineTest.class.getResourceAsStream("/pipelines/archiveController.groovy")),
                 StandardCharsets.UTF_8);
 
         // Setup wiremock stubs
-        setupWireMockStubs(pipelineName, wmRuntimeInfo, "", "artifact.txt", "stash.tgz");
+        setupWireMockStubs(pipelineName, wmRuntimeInfo, prefix, artifact, "stash.tgz");
 
         // Run job
         WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);
@@ -98,6 +112,10 @@ public class PipelineTest extends BaseTest {
 
         // Job success
         assertThat(run1.getResult(), equalTo(hudson.model.Result.SUCCESS));
+
+        // Verify artifact was uploaded
+        WireMock.verify(WireMock.putRequestedFor(WireMock.urlEqualTo(getArtifactUrl(prefix, pipelineName, artifact)))
+                .withRequestBody(WireMock.equalTo("Hello, World!")));
 
         // Check 1 artifact
         assertThat(run1.getArtifacts(), hasSize(1));
@@ -108,8 +126,10 @@ public class PipelineTest extends BaseTest {
             throws Exception {
 
         final String pipelineName = "testPipelineWithPrefix";
+        final String prefix = "jenkins/";
+        final String artifact = "artifact.txt";
 
-        configureConfig(jenkinsRule, wmRuntimeInfo, "jenkins/");
+        configureConfig(jenkinsRule, wmRuntimeInfo, prefix);
         String pipeline = IOUtils.toString(
                 Objects.requireNonNull(PipelineTest.class.getResourceAsStream("/pipelines/archiveAgent.groovy")),
                 StandardCharsets.UTF_8);
@@ -117,7 +137,7 @@ public class PipelineTest extends BaseTest {
         DumbSlave s = jenkinsRule.createSlave(Label.get("agent"));
 
         // Setup wiremock stubs
-        setupWireMockStubs(pipelineName, wmRuntimeInfo, "jenkins/", "artifact.txt", "stash.tgz");
+        setupWireMockStubs(pipelineName, wmRuntimeInfo, prefix, artifact, "stash.tgz");
 
         // Run job
         WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);
@@ -127,6 +147,10 @@ public class PipelineTest extends BaseTest {
 
         // Job success
         assertThat(run1.getResult(), equalTo(hudson.model.Result.SUCCESS));
+
+        // Verify artifact was uploaded
+        WireMock.verify(WireMock.putRequestedFor(WireMock.urlEqualTo(getArtifactUrl(prefix, pipelineName, artifact)))
+                .withRequestBody(WireMock.equalTo("Hello, World!")));
 
         // Check 1 artifact
         assertThat(run1.getArtifacts(), hasSize(1));
@@ -164,5 +188,9 @@ public class PipelineTest extends BaseTest {
         // HtmlSelect stageSelect = replayPage.getFirstByXPath("//select[@name='Result']");
         // final HtmlOption resultOption = stageSelect.getOptionByText("Result");
         // stageSelect.setSelectedAttribute(resultOption, true);
+    }
+
+    private String getArtifactUrl(String prefix, String pipelineName, String artifact) {
+        return ("/my-generic-repo/" + prefix + pipelineName + "/1/artifacts/" + artifact).replaceAll(" ", "%20");
     }
 }

--- a/src/test/resources/pipelines/archiveAgent.groovy
+++ b/src/test/resources/pipelines/archiveAgent.groovy
@@ -6,13 +6,8 @@ pipeline {
     stages {
         stage('Archive artifact') {
             steps {
-                script {
-                    if (isUnix()) {
-                        sh "echo 'Hello, World!' > artifact.txt"
-                    } else {
-                        bat "echo Hello, World! > artifact.txt"
-                    }
-                }
+                writeFile file: 'artifact.txt', text: 'Hello, World!'
+                archiveArtifacts artifacts: '*.txt', allowEmptyArchive: false
             }
         }
     }

--- a/src/test/resources/pipelines/archiveController.groovy
+++ b/src/test/resources/pipelines/archiveController.groovy
@@ -6,13 +6,8 @@ pipeline {
     stages {
         stage('Archive artifact') {
             steps {
-                script {
-                    if (isUnix()) {
-                        sh "echo 'Hello, World!' > artifact.txt"
-                    } else {
-                        bat "echo Hello, World! > artifact.txt"
-                    }
-                }
+                writeFile file: 'artifact.txt', text: 'Hello, World!'
+                archiveArtifacts artifacts: '*.txt', allowEmptyArchive: false
             }
         }
     }

--- a/src/test/resources/pipelines/archiveControllerWithSpaces.groovy
+++ b/src/test/resources/pipelines/archiveControllerWithSpaces.groovy
@@ -6,13 +6,8 @@ pipeline {
     stages {
         stage('Archive artifact') {
             steps {
-                script {
-                    if (isUnix()) {
-                        sh "echo 'Hello, World!' > 'my artifact.txt'"
-                    } else {
-                        bat "echo Hello, World! > my 'artifact.txt'"
-                    }
-                }
+                writeFile file: 'my artifact.txt', text: 'Hello, World!'
+                archiveArtifacts artifacts: '*.txt', allowEmptyArchive: false
             }
         }
     }

--- a/src/test/resources/pipelines/replay.groovy
+++ b/src/test/resources/pipelines/replay.groovy
@@ -6,27 +6,23 @@ pipeline {
     }
     stages {
         stage('Agent 1') {
-          agent {
-              label 'built-in'
-          }
-          steps {
-            script {
-              if (isUnix()) {
-                sh 'mkdir target && echo "Hello" > target/foo.txt'
-              } else {
-                bat 'mkdir target && echo "Hello" > target/foo.txt'
-              }
+            agent {
+                label 'built-in'
             }
-            stash(name: 'stash', includes: 'target/**')
-          }
+            steps {
+                dir('target') {
+                    writeFile file: 'foo.txt', text: 'Hello'
+                }
+                stash(name: 'stash', includes: 'target/**')
+            }
         }
         stage('Result') {
-          agent {
-              label 'built-in'
-          }
-          steps {
-            unstash(name: 'stash')
-          }
+            agent {
+                label 'built-in'
+            }
+            steps {
+                unstash(name: 'stash')
+            }
         }
     }
 }


### PR DESCRIPTION
We noticed that archiving artifacts takes much time when archiving many small files.
With this change 4 will be uploaded in parallel.

### Testing done

Test with a local artifactory oss instance are working. Upload time is much faster.

The Pipeline tests are now archiving files and verify if they were uploaded.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
