### PR TITLE
JENKINS-73398: Take snapshot of credentials

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.artifactory_artifacts;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.UsernamePasswordCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -253,7 +254,7 @@ class ArtifactoryClient implements AutoCloseable {
         public ArtifactoryConfig(String serverUrl, String repository, UsernamePasswordCredentials credentials) {
             this.serverUrl = serverUrl;
             this.repository = repository;
-            this.credentials = credentials;
+            this.credentials = CredentialsProvider.snapshot(UsernamePasswordCredentials.class, credentials);
         }
 
         public String getServerUrl() {


### PR DESCRIPTION
Before transferring the credentials to a remote agent, take a snapshot of them to avoid any dependencies on external services.

To support the HashiCorp Vault credentials type, this also depends on jenkinsci/hashicorp-vault-plugin#334.

<!-- Please describe your pull request here. -->

### Testing done

Have run this locally in combination with jenkinsci/hashicorp-vault-plugin#334 and it works a charm.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
