### PR TITLE
Implement retry mechanism

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManager.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManager.java
@@ -300,8 +300,9 @@ public class ArtifactoryArtifactManager extends ArtifactManager implements Stash
                     listener.getLogger().printf("Stashed %d file(s) to %s%n", count, path);
                 } catch (RuntimeException e) {
                     String message = this.config.getMaxUploadRetries() == 0
-                        ? "Unable to stash files to Artifactory on first attempt (no retries configured)"
-                        : "Unable to stash files to Artifactory after " + this.config.getMaxUploadRetries() + " attempts";
+                            ? "Unable to stash files to Artifactory on first attempt (no retries configured)"
+                            : "Unable to stash files to Artifactory after " + this.config.getMaxUploadRetries()
+                                    + " attempts";
                     throw new AbortException(message + ". Details: " + e.getMessage());
                 }
             } finally {
@@ -483,7 +484,7 @@ public class ArtifactoryArtifactManager extends ArtifactManager implements Stash
 
         // When maxRetries is 0, try once and fail immediately if there's an error
         int maxAttempts = Math.max(1, maxRetries);
-        
+
         int attempt = 0;
         while (attempt < maxAttempts) {
             try {
@@ -493,12 +494,11 @@ public class ArtifactoryArtifactManager extends ArtifactManager implements Stash
             } catch (Exception e) {
                 attempt++;
                 if (attempt >= maxAttempts) {
-                    String message = maxRetries == 0 
-                        ? String.format("%s on first attempt (no retries configured)", failureMessage)
-                        : String.format("%s after %d attempts", failureMessage, maxRetries);
+                    String message = maxRetries == 0
+                            ? String.format("%s on first attempt (no retries configured)", failureMessage)
+                            : String.format("%s after %d attempts", failureMessage, maxRetries);
                     LOGGER.error(message, e);
-                    throw new RuntimeException(
-                            String.format("%s: %s", message, e.getMessage()), e);
+                    throw new RuntimeException(String.format("%s: %s", message, e.getMessage()), e);
                 } else {
                     LOGGER.warn(String.format(
                             "%s attempt %d failed, retrying in %dms: %s",

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManagerFactory.java
@@ -7,10 +7,10 @@ import hudson.model.Run;
 import jenkins.model.ArtifactManager;
 import jenkins.model.ArtifactManagerFactory;
 import jenkins.model.ArtifactManagerFactoryDescriptor;
+import org.jenkinsci.Symbol;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.jenkinsci.Symbol;
 
 @Restricted(NoExternalUse.class)
 public class ArtifactoryArtifactManagerFactory extends ArtifactManagerFactory {

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManagerFactory.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryArtifactManagerFactory.java
@@ -10,6 +10,7 @@ import jenkins.model.ArtifactManagerFactoryDescriptor;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.jenkinsci.Symbol;
 
 @Restricted(NoExternalUse.class)
 public class ArtifactoryArtifactManagerFactory extends ArtifactManagerFactory {
@@ -35,6 +36,7 @@ public class ArtifactoryArtifactManagerFactory extends ArtifactManagerFactory {
     }
 
     @Extension
+    @Symbol("artifactory")
     public static final class DescriptorImpl extends ArtifactManagerFactoryDescriptor {
         @NonNull
         @Override

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
@@ -254,7 +254,7 @@ class ArtifactoryClient implements AutoCloseable {
         private final long retryDelaySeconds;
 
         public ArtifactoryConfig(String serverUrl, String repository, UsernamePasswordCredentials credentials) {
-            this(serverUrl, repository, credentials, 3, 15);
+            this(serverUrl, repository, credentials, 0, 5);
         }
 
         public ArtifactoryConfig(

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
@@ -254,9 +254,12 @@ class ArtifactoryClient implements AutoCloseable {
         private final int retryDelaySeconds;
 
         public ArtifactoryConfig(String serverUrl, String repository, UsernamePasswordCredentials credentials) {
-            this(serverUrl, repository, credentials, 
-                ArtifactoryGenericArtifactConfig.DEFAULT_MAX_UPLOAD_RETRIES, 
-                ArtifactoryGenericArtifactConfig.DEFAULT_RETRY_DELAY_SECONDS);
+            this(
+                    serverUrl,
+                    repository,
+                    credentials,
+                    ArtifactoryGenericArtifactConfig.DEFAULT_MAX_UPLOAD_RETRIES,
+                    ArtifactoryGenericArtifactConfig.DEFAULT_RETRY_DELAY_SECONDS);
         }
 
         public ArtifactoryConfig(

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
@@ -251,7 +251,7 @@ class ArtifactoryClient implements AutoCloseable {
         private final String repository;
         private final UsernamePasswordCredentials credentials;
         private final int maxUploadRetries;
-        private final long retryDelaySeconds;
+        private final int retryDelaySeconds;
 
         public ArtifactoryConfig(String serverUrl, String repository, UsernamePasswordCredentials credentials) {
             this(serverUrl, repository, credentials, 0, 5);
@@ -262,7 +262,7 @@ class ArtifactoryClient implements AutoCloseable {
                 String repository,
                 UsernamePasswordCredentials credentials,
                 int maxUploadRetries,
-                long retryDelaySeconds) {
+                int retryDelaySeconds) {
             this.serverUrl = serverUrl;
             this.repository = repository;
             this.credentials = CredentialsProvider.snapshot(UsernamePasswordCredentials.class, credentials);
@@ -286,7 +286,7 @@ class ArtifactoryClient implements AutoCloseable {
             return maxUploadRetries;
         }
 
-        public long getRetryDelaySeconds() {
+        public int getRetryDelaySeconds() {
             return retryDelaySeconds;
         }
     }

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
@@ -250,11 +250,24 @@ class ArtifactoryClient implements AutoCloseable {
         private final String serverUrl;
         private final String repository;
         private final UsernamePasswordCredentials credentials;
+        private final int maxUploadRetries;
+        private final long retryDelaySeconds;
 
         public ArtifactoryConfig(String serverUrl, String repository, UsernamePasswordCredentials credentials) {
+            this(serverUrl, repository, credentials, 3, 15);
+        }
+
+        public ArtifactoryConfig(
+                String serverUrl,
+                String repository,
+                UsernamePasswordCredentials credentials,
+                int maxUploadRetries,
+                long retryDelaySeconds) {
             this.serverUrl = serverUrl;
             this.repository = repository;
             this.credentials = CredentialsProvider.snapshot(UsernamePasswordCredentials.class, credentials);
+            this.maxUploadRetries = maxUploadRetries;
+            this.retryDelaySeconds = retryDelaySeconds;
         }
 
         public String getServerUrl() {
@@ -267,6 +280,14 @@ class ArtifactoryClient implements AutoCloseable {
 
         public UsernamePasswordCredentials getCredentials() {
             return credentials;
+        }
+
+        public int getMaxUploadRetries() {
+            return maxUploadRetries;
+        }
+
+        public long getRetryDelaySeconds() {
+            return retryDelaySeconds;
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryClient.java
@@ -254,7 +254,9 @@ class ArtifactoryClient implements AutoCloseable {
         private final int retryDelaySeconds;
 
         public ArtifactoryConfig(String serverUrl, String repository, UsernamePasswordCredentials credentials) {
-            this(serverUrl, repository, credentials, 0, 5);
+            this(serverUrl, repository, credentials, 
+                ArtifactoryGenericArtifactConfig.DEFAULT_MAX_UPLOAD_RETRIES, 
+                ArtifactoryGenericArtifactConfig.DEFAULT_RETRY_DELAY_SECONDS);
         }
 
         public ArtifactoryConfig(

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
@@ -63,8 +63,12 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
     }
 
     public ArtifactoryGenericArtifactConfig(
-            String storageCredentialId, String serverUrl, String repository, String prefix, 
-            int maxUploadRetries, int retryDelaySeconds) {
+            String storageCredentialId,
+            String serverUrl,
+            String repository,
+            String prefix,
+            int maxUploadRetries,
+            int retryDelaySeconds) {
         this.storageCredentialId = storageCredentialId;
         this.serverUrl = serverUrl;
         this.repository = repository;

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
@@ -111,7 +111,7 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
 
     @DataBoundSetter
     public void setMaxUploadRetries(int maxUploadRetries) {
-        this.maxUploadRetries = Math.max(1, maxUploadRetries); // Minimum 1 retry
+        this.maxUploadRetries = Math.max(0, maxUploadRetries); // Minimum 0 retries (no retries)
     }
 
     public long getRetryDelaySeconds() {
@@ -120,7 +120,7 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
 
     @DataBoundSetter
     public void setRetryDelaySeconds(long retryDelaySeconds) {
-        this.retryDelaySeconds = Math.max(1, retryDelaySeconds); // Minimum 1 second
+        this.retryDelaySeconds = Math.max(0, retryDelaySeconds); // Minimum 0 seconds (no delay)
     }
 
     public static ArtifactoryGenericArtifactConfig get() {
@@ -208,11 +208,14 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
         @SuppressWarnings("lgtm[jenkins/csrf]")
         public FormValidation doCheckMaxUploadRetries(@QueryParameter int maxUploadRetries) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            if (maxUploadRetries < 1) {
-                return FormValidation.error("Max retries must be at least 1");
+            if (maxUploadRetries < 0) {
+                return FormValidation.error("Max retries cannot be negative");
             }
             if (maxUploadRetries > 10) {
                 return FormValidation.warning("Consider using a lower number of retries to avoid long delays");
+            }
+            if (maxUploadRetries == 0) {
+                return FormValidation.ok("No retries - operations will fail immediately on first error");
             }
             return FormValidation.ok();
         }
@@ -220,11 +223,14 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
         @SuppressWarnings("lgtm[jenkins/csrf]")
         public FormValidation doCheckRetryDelaySeconds(@QueryParameter long retryDelaySeconds) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            if (retryDelaySeconds < 1) {
-                return FormValidation.error("Retry delay must be at least 1 second");
+            if (retryDelaySeconds < 0) {
+                return FormValidation.error("Retry delay cannot be negative");
             }
             if (retryDelaySeconds > 300) {
                 return FormValidation.warning("Consider using a shorter delay to avoid very long waits");
+            }
+            if (retryDelaySeconds == 0) {
+                return FormValidation.ok("No delay - retries will happen immediately");
             }
             return FormValidation.ok();
         }

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
@@ -42,8 +42,8 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
     private String serverUrl;
     private String repository;
     private String prefix;
-    private int maxUploadRetries = 3;
-    private long retryDelaySeconds = 15;
+    private int maxUploadRetries = 0;
+    private long retryDelaySeconds = 5;
 
     @DataBoundConstructor
     public ArtifactoryGenericArtifactConfig() {}
@@ -54,8 +54,8 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
         this.serverUrl = serverUrl;
         this.repository = repository;
         this.prefix = prefix;
-        this.maxUploadRetries = 3;
-        this.retryDelaySeconds = 15;
+        this.maxUploadRetries = 0;
+        this.retryDelaySeconds = 5;
     }
 
     public ArtifactoryGenericArtifactConfig(

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
@@ -43,7 +43,7 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
     private String repository;
     private String prefix;
     private int maxUploadRetries = 0;
-    private long retryDelaySeconds = 5;
+    private int retryDelaySeconds = 5;
 
     @DataBoundConstructor
     public ArtifactoryGenericArtifactConfig() {}
@@ -114,12 +114,12 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
         this.maxUploadRetries = Math.max(0, maxUploadRetries); // Minimum 0 retries (no retries)
     }
 
-    public long getRetryDelaySeconds() {
+    public int getRetryDelaySeconds() {
         return retryDelaySeconds;
     }
 
     @DataBoundSetter
-    public void setRetryDelaySeconds(long retryDelaySeconds) {
+    public void setRetryDelaySeconds(int retryDelaySeconds) {
         this.retryDelaySeconds = Math.max(0, retryDelaySeconds); // Minimum 0 seconds (no delay)
     }
 
@@ -221,7 +221,7 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
         }
 
         @SuppressWarnings("lgtm[jenkins/csrf]")
-        public FormValidation doCheckRetryDelaySeconds(@QueryParameter long retryDelaySeconds) {
+        public FormValidation doCheckRetryDelaySeconds(@QueryParameter int retryDelaySeconds) {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
             if (retryDelaySeconds < 0) {
                 return FormValidation.error("Retry delay cannot be negative");

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
@@ -38,12 +38,16 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
 
     public static final Logger LOGGER = LoggerFactory.getLogger(ArtifactoryGenericArtifactConfig.class);
 
+    // Default values for retry configuration
+    public static final int DEFAULT_MAX_UPLOAD_RETRIES = 0;
+    public static final int DEFAULT_RETRY_DELAY_SECONDS = 5;
+
     private String storageCredentialId;
     private String serverUrl;
     private String repository;
     private String prefix;
-    private int maxUploadRetries = 0;
-    private int retryDelaySeconds = 5;
+    private int maxUploadRetries = DEFAULT_MAX_UPLOAD_RETRIES;
+    private int retryDelaySeconds = DEFAULT_RETRY_DELAY_SECONDS;
 
     @DataBoundConstructor
     public ArtifactoryGenericArtifactConfig() {}
@@ -54,8 +58,8 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
         this.serverUrl = serverUrl;
         this.repository = repository;
         this.prefix = prefix;
-        this.maxUploadRetries = 0;
-        this.retryDelaySeconds = 5;
+        this.maxUploadRetries = DEFAULT_MAX_UPLOAD_RETRIES;
+        this.retryDelaySeconds = DEFAULT_RETRY_DELAY_SECONDS;
     }
 
     public ArtifactoryGenericArtifactConfig(

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.jelly
@@ -15,10 +15,10 @@
                         <f:textbox/>
                 </f:entry>
                 <f:entry title="${%MaxUploadRetries_title}" field="maxUploadRetries">
-                        <f:number min="0" max="10" default="3"/>
+                        <f:number min="0" max="10" default="0"/>
                 </f:entry>
                 <f:entry title="${%RetryDelaySeconds_title}" field="retryDelaySeconds">
-                        <f:number min="0" max="300" default="15"/>
+                        <f:number min="0" max="300" default="5"/>
                 </f:entry>
                 <f:validateButton title="Validate Artifactory configuration" progress="Validate..." method="validateArtifactoryConfig"
                                   with="prefix,serverUrl,storageCredentialId,repository"/>

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.jelly
@@ -14,6 +14,12 @@
                 <f:entry title="${%Prefix_title}" field="prefix">
                         <f:textbox/>
                 </f:entry>
+                <f:entry title="${%MaxUploadRetries_title}" field="maxUploadRetries">
+                        <f:number min="1" max="10" default="3"/>
+                </f:entry>
+                <f:entry title="${%RetryDelaySeconds_title}" field="retryDelaySeconds">
+                        <f:number min="1" max="300" default="15"/>
+                </f:entry>
                 <f:validateButton title="Validate Artifactory configuration" progress="Validate..." method="validateArtifactoryConfig"
                                   with="prefix,serverUrl,storageCredentialId,repository"/>
         </f:section>

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.jelly
@@ -15,10 +15,10 @@
                         <f:textbox/>
                 </f:entry>
                 <f:entry title="${%MaxUploadRetries_title}" field="maxUploadRetries">
-                        <f:number min="1" max="10" default="3"/>
+                        <f:number min="0" max="10" default="3"/>
                 </f:entry>
                 <f:entry title="${%RetryDelaySeconds_title}" field="retryDelaySeconds">
-                        <f:number min="1" max="300" default="15"/>
+                        <f:number min="0" max="300" default="15"/>
                 </f:entry>
                 <f:validateButton title="Validate Artifactory configuration" progress="Validate..." method="validateArtifactoryConfig"
                                   with="prefix,serverUrl,storageCredentialId,repository"/>

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.properties
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.properties
@@ -3,3 +3,5 @@ Credentials_title=Artifactory Credentials
 Repository_name_title=Repository Name
 ServerUrl_name_title=Server URL
 Prefix_title=Base Prefix (Optional)
+MaxUploadRetries_title=Max Upload Retries
+RetryDelaySeconds_title=Retry Delay (seconds)

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-maxUploadRetries.html
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-maxUploadRetries.html
@@ -1,0 +1,12 @@
+<div>
+  <p>
+    Specify the maximum number of times to retry uploading artifacts to Artifactory when a failure occurs.
+  </p>
+  <p>
+    The default value is 3 retries. Higher values provide more resilience against transient network issues,
+    but may cause jobs to take longer when Artifactory is persistently unavailable.
+  </p>
+  <p>
+    <strong>Recommended range:</strong> 1-5 retries for most use cases.
+  </p>
+</div>

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-maxUploadRetries.html
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-maxUploadRetries.html
@@ -7,6 +7,9 @@
     but may cause jobs to take longer when Artifactory is persistently unavailable.
   </p>
   <p>
-    <strong>Recommended range:</strong> 1-5 retries for most use cases.
+    Set to 0 to disable retries - operations will fail immediately on the first error.
+  </p>
+  <p>
+    <strong>Recommended range:</strong> 0-5 retries for most use cases.
   </p>
 </div>

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-maxUploadRetries.html
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-maxUploadRetries.html
@@ -3,7 +3,7 @@
     Specify the maximum number of times to retry uploading artifacts to Artifactory when a failure occurs.
   </p>
   <p>
-    The default value is 3 retries. Higher values provide more resilience against transient network issues,
+    The default value is 0 retries (no retries). Higher values provide more resilience against transient network issues,
     but may cause jobs to take longer when Artifactory is persistently unavailable.
   </p>
   <p>

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-retryDelaySeconds.html
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-retryDelaySeconds.html
@@ -1,0 +1,12 @@
+<div>
+  <p>
+    Specify the delay in seconds between retry attempts when uploading artifacts to Artifactory fails.
+  </p>
+  <p>
+    The default value is 15 seconds. Shorter delays may cause retries to fail if the issue is temporary,
+    while longer delays may unnecessarily extend job execution time.
+  </p>
+  <p>
+    <strong>Recommended range:</strong> 5-30 seconds for most network environments.
+  </p>
+</div>

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-retryDelaySeconds.html
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-retryDelaySeconds.html
@@ -3,13 +3,13 @@
     Specify the delay in seconds between retry attempts when uploading artifacts to Artifactory fails.
   </p>
   <p>
-    The default value is 15 seconds. Shorter delays may cause retries to fail if the issue is temporary,
+    The default value is 5 seconds. Shorter delays may cause retries to fail if the issue is temporary,
     while longer delays may unnecessarily extend job execution time.
   </p>
   <p>
     Set to 0 to retry immediately without any delay between attempts.
   </p>
   <p>
-    <strong>Recommended range:</strong> 0-30 seconds for most network environments.
+    <strong>Recommended range:</strong> 5-30 seconds for most network environments.
   </p>
 </div>

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-retryDelaySeconds.html
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-retryDelaySeconds.html
@@ -7,6 +7,9 @@
     while longer delays may unnecessarily extend job execution time.
   </p>
   <p>
-    <strong>Recommended range:</strong> 5-30 seconds for most network environments.
+    Set to 0 to retry immediately without any delay between attempts.
+  </p>
+  <p>
+    <strong>Recommended range:</strong> 0-30 seconds for most network environments.
   </p>
 </div>

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
@@ -14,8 +14,8 @@ public class ArtifactoryRetryConfigTest {
     public void shouldHaveDefaultRetryValues() {
         ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
 
-        assertThat("Default max upload retries should be 3", config.getMaxUploadRetries(), equalTo(3));
-        assertThat("Default retry delay should be 15 seconds", config.getRetryDelaySeconds(), equalTo(15L));
+        assertThat("Default max upload retries should be 0", config.getMaxUploadRetries(), equalTo(0));
+        assertThat("Default retry delay should be 5 seconds", config.getRetryDelaySeconds(), equalTo(5L));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
@@ -30,15 +30,27 @@ public class ArtifactoryRetryConfigTest {
     }
 
     @Test
-    public void shouldValidateMinimumRetryValues() {
+    public void shouldAllowZeroRetryValues() {
         ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
 
         config.setMaxUploadRetries(0);
         config.setRetryDelaySeconds(0);
 
-        // Should enforce minimum values
-        assertThat("Min retries should be enforced", config.getMaxUploadRetries(), equalTo(1));
-        assertThat("Min delay should be enforced", config.getRetryDelaySeconds(), equalTo(1L));
+        // Should allow zero values
+        assertThat("Zero retries should be allowed", config.getMaxUploadRetries(), equalTo(0));
+        assertThat("Zero delay should be allowed", config.getRetryDelaySeconds(), equalTo(0L));
+    }
+
+    @Test
+    public void shouldPreventNegativeRetryValues() {
+        ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
+
+        config.setMaxUploadRetries(-1);
+        config.setRetryDelaySeconds(-1);
+
+        // Should enforce minimum of 0
+        assertThat("Negative retries should be set to 0", config.getMaxUploadRetries(), equalTo(0));
+        assertThat("Negative delay should be set to 0", config.getRetryDelaySeconds(), equalTo(0L));
     }
 
     @Test
@@ -54,5 +66,20 @@ public class ArtifactoryRetryConfigTest {
                 "Config should have custom retry delay",
                 config.getRetryDelaySeconds(),
                 equalTo(30L));
+    }
+
+    @Test
+    public void shouldCreateConfigWithZeroRetryValues() {
+        ArtifactoryGenericArtifactConfig config =
+                new ArtifactoryGenericArtifactConfig("cred-id", "http://localhost:8081", "repo", "prefix", 0, 0);
+
+        assertThat(
+                "Config should allow zero retry count",
+                config.getMaxUploadRetries(),
+                equalTo(0));
+        assertThat(
+                "Config should allow zero retry delay",
+                config.getRetryDelaySeconds(),
+                equalTo(0L));
     }
 }

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
@@ -15,7 +15,7 @@ public class ArtifactoryRetryConfigTest {
         ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
 
         assertThat("Default max upload retries should be 0", config.getMaxUploadRetries(), equalTo(0));
-        assertThat("Default retry delay should be 5 seconds", config.getRetryDelaySeconds(), equalTo(5L));
+        assertThat("Default retry delay should be 5 seconds", config.getRetryDelaySeconds(), equalTo(5));
     }
 
     @Test
@@ -26,7 +26,7 @@ public class ArtifactoryRetryConfigTest {
         config.setRetryDelaySeconds(30);
 
         assertThat("Max upload retries should be configurable", config.getMaxUploadRetries(), equalTo(5));
-        assertThat("Retry delay should be configurable", config.getRetryDelaySeconds(), equalTo(30L));
+        assertThat("Retry delay should be configurable", config.getRetryDelaySeconds(), equalTo(30));
     }
 
     @Test
@@ -38,7 +38,7 @@ public class ArtifactoryRetryConfigTest {
 
         // Should allow zero values
         assertThat("Zero retries should be allowed", config.getMaxUploadRetries(), equalTo(0));
-        assertThat("Zero delay should be allowed", config.getRetryDelaySeconds(), equalTo(0L));
+        assertThat("Zero delay should be allowed", config.getRetryDelaySeconds(), equalTo(0));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class ArtifactoryRetryConfigTest {
 
         // Should enforce minimum of 0
         assertThat("Negative retries should be set to 0", config.getMaxUploadRetries(), equalTo(0));
-        assertThat("Negative delay should be set to 0", config.getRetryDelaySeconds(), equalTo(0L));
+        assertThat("Negative delay should be set to 0", config.getRetryDelaySeconds(), equalTo(0));
     }
 
     @Test
@@ -65,7 +65,7 @@ public class ArtifactoryRetryConfigTest {
         assertThat(
                 "Config should have custom retry delay",
                 config.getRetryDelaySeconds(),
-                equalTo(30L));
+                equalTo(30));
     }
 
     @Test
@@ -80,6 +80,6 @@ public class ArtifactoryRetryConfigTest {
         assertThat(
                 "Config should allow zero retry delay",
                 config.getRetryDelaySeconds(),
-                equalTo(0L));
+                equalTo(0));
     }
 }

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
@@ -1,0 +1,58 @@
+package io.jenkins.plugins.artifactory_artifacts;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for configurable retry mechanism in ArtifactoryGenericArtifactConfig.
+ */
+public class ArtifactoryRetryConfigTest {
+
+    @Test
+    public void shouldHaveDefaultRetryValues() {
+        ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
+
+        assertThat("Default max upload retries should be 3", config.getMaxUploadRetries(), equalTo(3));
+        assertThat("Default retry delay should be 15 seconds", config.getRetryDelaySeconds(), equalTo(15L));
+    }
+
+    @Test
+    public void shouldAllowCustomRetryValues() {
+        ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
+
+        config.setMaxUploadRetries(5);
+        config.setRetryDelaySeconds(30);
+
+        assertThat("Max upload retries should be configurable", config.getMaxUploadRetries(), equalTo(5));
+        assertThat("Retry delay should be configurable", config.getRetryDelaySeconds(), equalTo(30L));
+    }
+
+    @Test
+    public void shouldValidateMinimumRetryValues() {
+        ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
+
+        config.setMaxUploadRetries(0);
+        config.setRetryDelaySeconds(0);
+
+        // Should enforce minimum values
+        assertThat("Min retries should be enforced", config.getMaxUploadRetries(), equalTo(1));
+        assertThat("Min delay should be enforced", config.getRetryDelaySeconds(), equalTo(1L));
+    }
+
+    @Test
+    public void shouldCreateConfigWithCustomRetryValues() {
+        ArtifactoryGenericArtifactConfig config =
+                new ArtifactoryGenericArtifactConfig("cred-id", "http://localhost:8081", "repo", "prefix", 5, 30);
+
+        assertThat(
+                "Config should have custom retry count",
+                config.getMaxUploadRetries(),
+                equalTo(5));
+        assertThat(
+                "Config should have custom retry delay",
+                config.getRetryDelaySeconds(),
+                equalTo(30L));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
@@ -58,14 +58,8 @@ public class ArtifactoryRetryConfigTest {
         ArtifactoryGenericArtifactConfig config =
                 new ArtifactoryGenericArtifactConfig("cred-id", "http://localhost:8081", "repo", "prefix", 5, 30);
 
-        assertThat(
-                "Config should have custom retry count",
-                config.getMaxUploadRetries(),
-                equalTo(5));
-        assertThat(
-                "Config should have custom retry delay",
-                config.getRetryDelaySeconds(),
-                equalTo(30));
+        assertThat("Config should have custom retry count", config.getMaxUploadRetries(), equalTo(5));
+        assertThat("Config should have custom retry delay", config.getRetryDelaySeconds(), equalTo(30));
     }
 
     @Test
@@ -73,13 +67,7 @@ public class ArtifactoryRetryConfigTest {
         ArtifactoryGenericArtifactConfig config =
                 new ArtifactoryGenericArtifactConfig("cred-id", "http://localhost:8081", "repo", "prefix", 0, 0);
 
-        assertThat(
-                "Config should allow zero retry count",
-                config.getMaxUploadRetries(),
-                equalTo(0));
-        assertThat(
-                "Config should allow zero retry delay",
-                config.getRetryDelaySeconds(),
-                equalTo(0));
+        assertThat("Config should allow zero retry count", config.getMaxUploadRetries(), equalTo(0));
+        assertThat("Config should allow zero retry delay", config.getRetryDelaySeconds(), equalTo(0));
     }
 }

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryMechanismTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryMechanismTest.java
@@ -249,7 +249,7 @@ public class ArtifactoryRetryMechanismTest extends BaseTest {
         // Configure with 0 retries
         ArtifactoryGenericArtifactConfig config = configureConfig(jenkinsRule, wmRuntimeInfo.getHttpPort(), "");
         config.setMaxUploadRetries(0);
-        
+
         String pipelineName = "shouldFailImmediatelyWithZeroRetries";
 
         // Create pipeline that archives a file
@@ -263,12 +263,11 @@ public class ArtifactoryRetryMechanismTest extends BaseTest {
 
         // Setup WireMock to always fail
         WireMock wireMock = wmRuntimeInfo.getWireMock();
-        wireMock.register(WireMock.put(WireMock.urlMatching("/my-generic-repo/.*"))
-                .willReturn(WireMock.serverError()));
+        wireMock.register(
+                WireMock.put(WireMock.urlMatching("/my-generic-repo/.*")).willReturn(WireMock.serverError()));
 
         // Setup other required stubs
-        setupOtherWireMockStubs(
-                pipelineName, wireMock, wmRuntimeInfo.getHttpPort(), "", "artifact.txt", "stash.tgz");
+        setupOtherWireMockStubs(pipelineName, wireMock, wmRuntimeInfo.getHttpPort(), "", "artifact.txt", "stash.tgz");
 
         // Run the pipeline
         WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryMechanismTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryMechanismTest.java
@@ -1,0 +1,259 @@
+package io.jenkins.plugins.artifactory_artifacts;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import java.util.Objects;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Tests for the retry mechanism implementation in ArtifactoryArtifactManager.
+ * These tests validate that uploads retry on failure and eventually succeed or fail appropriately.
+ */
+@WithJenkins
+@WireMockTest
+public class ArtifactoryRetryMechanismTest extends BaseTest {
+
+    @Test
+    public void shouldRetryArtifactUploadOnTransientFailure(JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo)
+            throws Exception {
+        configureConfig(jenkinsRule, wmRuntimeInfo.getHttpPort(), "");
+        String pipelineName = "shouldRetryArtifactUploadOnTransientFailure";
+
+        // Create pipeline that archives a simple file
+        String pipeline =
+                """
+            node {
+                writeFile file: 'artifact.txt', text: 'Hello World'
+                archiveArtifacts artifacts: 'artifact.txt'
+            }
+            """;
+
+        // Setup WireMock to fail on first 2 attempts, succeed on 3rd
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+
+        // Scenario to simulate transient failures
+        String scenarioName = "retry-scenario";
+
+        // First attempt fails with 500
+        wireMock.register(WireMock.put(WireMock.urlMatching("/my-generic-repo/.*"))
+                .inScenario(scenarioName)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(WireMock.serverError())
+                .willSetStateTo("second-attempt"));
+
+        // Second attempt fails with 503
+        wireMock.register(WireMock.put(WireMock.urlMatching("/my-generic-repo/.*"))
+                .inScenario(scenarioName)
+                .whenScenarioStateIs("second-attempt")
+                .willReturn(WireMock.serviceUnavailable())
+                .willSetStateTo("third-attempt"));
+
+        // Third attempt succeeds
+        wireMock.register(WireMock.put(WireMock.urlMatching("/my-generic-repo/.*"))
+                .inScenario(scenarioName)
+                .whenScenarioStateIs("third-attempt")
+                .willReturn(WireMock.okJson("{}")));
+
+        // Setup other required stubs (excluding PUT which we handle above)
+        setupOtherWireMockStubs(pipelineName, wireMock, wmRuntimeInfo.getHttpPort(), "", "artifact.txt", "stash.tgz");
+
+        // Run the pipeline
+        WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);
+        workflowJob.setDefinition(new CpsFlowDefinition(pipeline, true));
+        WorkflowRun run = Objects.requireNonNull(workflowJob.scheduleBuild2(0)).waitForStart();
+        jenkinsRule.waitForCompletion(run);
+
+        // Should succeed after retries
+        assertThat(run.getResult(), equalTo(hudson.model.Result.SUCCESS));
+
+        // Verify all 3 requests were made
+        wireMock.verifyThat(3, WireMock.putRequestedFor(WireMock.urlMatching("/my-generic-repo/.*")));
+    }
+
+    @Test
+    public void shouldFailArtifactUploadAfterMaxRetries(JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo)
+            throws Exception {
+        configureConfig(jenkinsRule, wmRuntimeInfo.getHttpPort(), "");
+        String pipelineName = "shouldFailArtifactUploadAfterMaxRetries";
+
+        // Create pipeline that archives a simple file
+        String pipeline =
+                """
+            node {
+                writeFile file: 'artifact.txt', text: 'Hello World'
+                archiveArtifacts artifacts: 'artifact.txt'
+            }
+            """;
+
+        // Setup WireMock to always fail
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(
+                WireMock.put(WireMock.urlMatching("/my-generic-repo/.*")).willReturn(WireMock.serverError()));
+
+        // Setup other required stubs (excluding PUT which we handle above)
+        setupOtherWireMockStubs(pipelineName, wireMock, wmRuntimeInfo.getHttpPort(), "", "artifact.txt", "stash.tgz");
+
+        // Run the pipeline
+        WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);
+        workflowJob.setDefinition(new CpsFlowDefinition(pipeline, true));
+        WorkflowRun run = Objects.requireNonNull(workflowJob.scheduleBuild2(0)).waitForStart();
+        jenkinsRule.waitForCompletion(run);
+
+        // Should fail after max retries
+        assertThat(run.getResult(), equalTo(hudson.model.Result.FAILURE));
+
+        // Verify exactly MAX_UPLOAD_RETRIES (3) requests were made
+        wireMock.verifyThat(3, WireMock.putRequestedFor(WireMock.urlMatching("/my-generic-repo/.*")));
+
+        // Check build log contains retry messages
+        String buildLog = run.getLog();
+        assertThat(buildLog, containsString("Unable to upload files to Artifactory"));
+    }
+
+    @Test
+    public void shouldRetryStashUploadOnTransientFailure(JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo)
+            throws Exception {
+        configureConfig(jenkinsRule, wmRuntimeInfo.getHttpPort(), "");
+        String pipelineName = "shouldRetryStashUploadOnTransientFailure";
+
+        // Create pipeline that creates a stash
+        String pipeline =
+                """
+            node {
+                writeFile file: 'stash-file.txt', text: 'Stash content'
+                stash name: 'test-stash', includes: 'stash-file.txt'
+            }
+            """;
+
+        // Setup WireMock to fail on first 2 attempts, succeed on 3rd
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+
+        String scenarioName = "stash-retry-scenario";
+
+        // First attempt fails
+        wireMock.register(WireMock.put(WireMock.urlMatching("/my-generic-repo/.*/stashes/.*"))
+                .inScenario(scenarioName)
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(WireMock.serverError())
+                .willSetStateTo("second-attempt"));
+
+        // Second attempt fails
+        wireMock.register(WireMock.put(WireMock.urlMatching("/my-generic-repo/.*/stashes/.*"))
+                .inScenario(scenarioName)
+                .whenScenarioStateIs("second-attempt")
+                .willReturn(WireMock.serviceUnavailable())
+                .willSetStateTo("third-attempt"));
+
+        // Third attempt succeeds
+        wireMock.register(WireMock.put(WireMock.urlMatching("/my-generic-repo/.*/stashes/.*"))
+                .inScenario(scenarioName)
+                .whenScenarioStateIs("third-attempt")
+                .willReturn(WireMock.okJson("{}")));
+
+        // Setup other required stubs (for artifacts that won't be created in this test)
+        setupOtherWireMockStubs(
+                pipelineName, wireMock, wmRuntimeInfo.getHttpPort(), "", "artifact.txt", "test-stash.tgz");
+
+        // Run the pipeline
+        WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);
+        workflowJob.setDefinition(new CpsFlowDefinition(pipeline, true));
+        WorkflowRun run = Objects.requireNonNull(workflowJob.scheduleBuild2(0)).waitForStart();
+        jenkinsRule.waitForCompletion(run);
+
+        // Should succeed after retries
+        assertThat(run.getResult(), equalTo(hudson.model.Result.SUCCESS));
+
+        // Verify all 3 stash upload requests were made
+        wireMock.verifyThat(3, WireMock.putRequestedFor(WireMock.urlMatching("/my-generic-repo/.*/stashes/.*")));
+    }
+
+    @Test
+    public void shouldFailStashUploadAfterMaxRetries(JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo)
+            throws Exception {
+        configureConfig(jenkinsRule, wmRuntimeInfo.getHttpPort(), "");
+        String pipelineName = "shouldFailStashUploadAfterMaxRetries";
+
+        // Create pipeline that creates a stash
+        String pipeline =
+                """
+            node {
+                writeFile file: 'stash-file.txt', text: 'Stash content'
+                stash name: 'test-stash', includes: 'stash-file.txt'
+            }
+            """;
+
+        // Setup WireMock to always fail for stash uploads
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(WireMock.put(WireMock.urlMatching("/my-generic-repo/.*/stashes/.*"))
+                .willReturn(WireMock.serverError()));
+
+        // Setup other required stubs
+        setupOtherWireMockStubs(
+                pipelineName, wireMock, wmRuntimeInfo.getHttpPort(), "", "artifact.txt", "test-stash.tgz");
+
+        // Run the pipeline
+        WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);
+        workflowJob.setDefinition(new CpsFlowDefinition(pipeline, true));
+        WorkflowRun run = Objects.requireNonNull(workflowJob.scheduleBuild2(0)).waitForStart();
+        jenkinsRule.waitForCompletion(run);
+
+        // Should fail after max retries
+        assertThat(run.getResult(), equalTo(hudson.model.Result.FAILURE));
+
+        // Verify exactly MAX_UPLOAD_RETRIES (3) stash upload requests were made
+        wireMock.verifyThat(3, WireMock.putRequestedFor(WireMock.urlMatching("/my-generic-repo/.*/stashes/.*")));
+
+        // Check build log contains retry messages
+        String buildLog = run.getLog();
+        assertThat(buildLog, containsString("Unable to stash files to Artifactory after 3 attempts"));
+    }
+
+    @Test
+    public void shouldSucceedImmediatelyWhenNoFailures(JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo)
+            throws Exception {
+        configureConfig(jenkinsRule, wmRuntimeInfo.getHttpPort(), "");
+        String pipelineName = "shouldSucceedImmediatelyWhenNoFailures";
+
+        // Create pipeline that archives a file and creates a stash
+        String pipeline =
+                """
+            node {
+                writeFile file: 'artifact.txt', text: 'Hello World'
+                writeFile file: 'stash-file.txt', text: 'Stash content'
+                archiveArtifacts artifacts: 'artifact.txt'
+                stash name: 'test-stash', includes: 'stash-file.txt'
+            }
+            """;
+
+        // Setup WireMock to always succeed
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(
+                WireMock.put(WireMock.urlMatching("/my-generic-repo/.*")).willReturn(WireMock.okJson("{}")));
+
+        // Setup other required stubs
+        setupOtherWireMockStubs(
+                pipelineName, wireMock, wmRuntimeInfo.getHttpPort(), "", "artifact.txt", "test-stash.tgz");
+
+        // Run the pipeline
+        WorkflowJob workflowJob = jenkinsRule.createProject(WorkflowJob.class, pipelineName);
+        workflowJob.setDefinition(new CpsFlowDefinition(pipeline, true));
+        WorkflowRun run = Objects.requireNonNull(workflowJob.scheduleBuild2(0)).waitForStart();
+        jenkinsRule.waitForCompletion(run);
+
+        // Should succeed immediately
+        assertThat(run.getResult(), equalTo(hudson.model.Result.SUCCESS));
+
+        // Verify only 2 requests were made (1 for artifact, 1 for stash) - no retries
+        wireMock.verifyThat(2, WireMock.putRequestedFor(WireMock.urlMatching("/my-generic-repo/.*")));
+    }
+}

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
@@ -15,12 +15,14 @@ public class BaseTest {
     protected ArtifactoryGenericArtifactConfig configureConfig(JenkinsRule jenkinsRule, int port, String prefix)
             throws Exception {
 
-        // Create generic config
+        // Create generic config with optimized retry settings for faster tests
         ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
         config.setPrefix(prefix);
         config.setServerUrl("http://localhost:" + port);
         config.setRepository("my-generic-repo");
         config.setStorageCredentialId("the-credentials-id");
+        config.setMaxUploadRetries(2);  // Use 2 retries for faster tests
+        config.setRetryDelaySeconds(1); // Use 1 second delay for faster tests
 
         // Add credentials to the store
         UsernamePasswordCredentialsImpl credentials = new UsernamePasswordCredentialsImpl(

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
@@ -21,7 +21,7 @@ public class BaseTest {
         config.setServerUrl("http://localhost:" + port);
         config.setRepository("my-generic-repo");
         config.setStorageCredentialId("the-credentials-id");
-        config.setMaxUploadRetries(2);  // Use 2 retries for faster tests
+        config.setMaxUploadRetries(2); // Use 2 retries for faster tests
         config.setRetryDelaySeconds(1); // Use 1 second delay for faster tests
 
         // Add credentials to the store

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/BaseTest.java
@@ -116,6 +116,83 @@ public class BaseTest {
                 WireMock.post(WireMock.urlMatching("/api/search/aql")).willReturn(WireMock.okJson(aqlResponse)));
     }
 
+    /**
+     * Setup WireMock stubs excluding PUT requests (for retry tests)
+     * @param wmRuntimeInfo the WireMock runtime info
+     */
+    protected void setupOtherWireMockStubs(
+            final String jobName, WireMock wireMock, int port, String prefix, String artifact, String stash) {
+
+        // Define the base URL
+        String artifactBasePath = "/api/storage/my-generic-repo/" + prefix + jobName + "/1/artifacts";
+        String stashApiBasePath = "/api/storage/my-generic-repo/" + prefix + jobName + "/1/stashes";
+        String stashFileBasePath = "/my-generic-repo/" + prefix + jobName + "/1/stashes";
+
+        // JSON response for folder with children
+        String artifactsResponse = "{"
+                + "\"children\": [{\"folder\": false, \"uri\": \"/" + artifact + "\"}],"
+                + "\"created\": \"2024-03-17T13:20:19.836Z\","
+                + "\"createdBy\": \"admin\","
+                + "\"lastModified\": \"2024-03-17T13:20:19.836Z\","
+                + "\"lastUpdated\": \"2024-03-17T13:20:19.836Z\","
+                + "\"modifiedBy\": \"admin\","
+                + "\"path\": \"" + artifactBasePath + "\","
+                + "\"repo\": \"my-generic-repo\","
+                + "\"uri\": \"http://localhost:" + port + "/artifactory" + artifactBasePath
+                + "\""
+                + "}";
+        String stashesResponse = "{"
+                + "\"children\": [{\"folder\": false, \"uri\": \"/" + artifact + "\"}],"
+                + "\"created\": \"2024-03-17T13:20:19.836Z\","
+                + "\"createdBy\": \"admin\","
+                + "\"lastModified\": \"2024-03-17T13:20:19.836Z\","
+                + "\"lastUpdated\": \"2024-03-17T13:20:19.836Z\","
+                + "\"modifiedBy\": \"admin\","
+                + "\"path\": \"" + stashFileBasePath + "\","
+                + "\"repo\": \"my-generic-repo\","
+                + "\"uri\": \"http://localhost:" + port + "/artifactory" + stashFileBasePath
+                + "\""
+                + "}";
+
+        String stashApiResponse = "{"
+                + "\"created\": \"2024-03-17T13:20:19.836Z\","
+                + "\"createdBy\": \"admin\","
+                + "\"lastModified\": \"2024-03-17T13:20:19.836Z\","
+                + "\"lastUpdated\": \"2024-03-17T13:20:19.836Z\","
+                + "\"modifiedBy\": \"admin\","
+                + "\"path\": \"" + stashApiBasePath + "/" + stash + "\","
+                + "\"repo\": \"my-generic-repo\","
+                + "\"uri\": \"http://localhost:" + port + "/artifactory" + stashApiBasePath + "/"
+                + stash + "\""
+                + "}";
+
+        // AQL response
+        String aqlResponse = "{\"results\": [{"
+                + "\"name\": \"" + artifact
+                + "\", \"type\": \"file\", \"modified\": \"2024-03-17T13:20:19.836Z\", \"size\": 1234,"
+                + "\"repo\": \"my-generic-repo\", \"path\": \"" + prefix + "/" + jobName + "/1/artifacts\"}]}";
+
+        // Register GET requests only (no PUT)
+
+        // Artifacts
+        wireMock.register(WireMock.get(WireMock.urlEqualTo(urlEncodeParts(artifactBasePath + "/")))
+                .willReturn(WireMock.okJson(artifactsResponse)));
+
+        // Stashes API
+        wireMock.register(WireMock.get(WireMock.urlEqualTo(urlEncodeParts(stashApiBasePath + "/" + stash)))
+                .willReturn(WireMock.okJson(stashApiResponse)));
+
+        // Stashes download
+        wireMock.register(WireMock.get(WireMock.urlEqualTo(urlEncodeParts(stashFileBasePath + "/")))
+                .willReturn(WireMock.okJson(stashesResponse)));
+        wireMock.register(WireMock.get(WireMock.urlEqualTo(urlEncodeParts(stashFileBasePath + "/" + stash)))
+                .willReturn(WireMock.ok().withBodyFile(stash).withHeader("Content-Type", "application/gzip")));
+
+        // Register POST request
+        wireMock.register(
+                WireMock.post(WireMock.urlMatching("/api/search/aql")).willReturn(WireMock.okJson(aqlResponse)));
+    }
+
     private String urlEncodeParts(String s) {
         return URLEncoder.encode(s, StandardCharsets.UTF_8)
                 .replaceAll("%2F", "/")

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ConfigurationAsCodeTest.java
@@ -24,7 +24,7 @@ public class ConfigurationAsCodeTest extends BaseTest {
         assertThat(config.getRepository(), is("my-generic-repo"));
         assertThat(config.getPrefix(), is("jenkins/"));
         assertThat(config.getMaxUploadRetries(), is(3));
-        assertThat(config.getRetryDelaySeconds(), is(10L));
+        assertThat(config.getRetryDelaySeconds(), is(10));
     }
 
     @Test
@@ -36,6 +36,6 @@ public class ConfigurationAsCodeTest extends BaseTest {
         assertThat(config.getRepository(), is("my-generic-repo"));
         assertThat(config.getPrefix(), is("jenkins/"));
         assertThat(config.getMaxUploadRetries(), is(0));
-        assertThat(config.getRetryDelaySeconds(), is(0L));
+        assertThat(config.getRetryDelaySeconds(), is(0));
     }
 }

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ConfigurationAsCodeTest.java
@@ -29,7 +29,8 @@ public class ConfigurationAsCodeTest extends BaseTest {
 
     @Test
     @ConfiguredWithCode("configuration-as-code-zero-retries.yml")
-    public void shouldSupportConfigurationAsCodeWithZeroRetries(JenkinsConfiguredWithCodeRule jenkinsRule) throws Exception {
+    public void shouldSupportConfigurationAsCodeWithZeroRetries(JenkinsConfiguredWithCodeRule jenkinsRule)
+            throws Exception {
         ArtifactoryGenericArtifactConfig config = Utils.getArtifactConfig();
         assertThat(config.getStorageCredentialId(), is("the-credentials-id"));
         assertThat(config.getServerUrl(), is("http://localhost:7000"));

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ConfigurationAsCodeTest.java
@@ -23,5 +23,19 @@ public class ConfigurationAsCodeTest extends BaseTest {
         assertThat(config.getServerUrl(), is("http://localhost:7000"));
         assertThat(config.getRepository(), is("my-generic-repo"));
         assertThat(config.getPrefix(), is("jenkins/"));
+        assertThat(config.getMaxUploadRetries(), is(3));
+        assertThat(config.getRetryDelaySeconds(), is(10L));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code-zero-retries.yml")
+    public void shouldSupportConfigurationAsCodeWithZeroRetries(JenkinsConfiguredWithCodeRule jenkinsRule) throws Exception {
+        ArtifactoryGenericArtifactConfig config = Utils.getArtifactConfig();
+        assertThat(config.getStorageCredentialId(), is("the-credentials-id"));
+        assertThat(config.getServerUrl(), is("http://localhost:7000"));
+        assertThat(config.getRepository(), is("my-generic-repo"));
+        assertThat(config.getPrefix(), is("jenkins/"));
+        assertThat(config.getMaxUploadRetries(), is(0));
+        assertThat(config.getRetryDelaySeconds(), is(0L));
     }
 }

--- a/src/test/resources/io/jenkins/plugins/artifactory_artifacts/configuration-as-code-zero-retries.yml
+++ b/src/test/resources/io/jenkins/plugins/artifactory_artifacts/configuration-as-code-zero-retries.yml
@@ -7,5 +7,5 @@ unclassified:
             repository: "my-generic-repo"
             serverUrl: "http://localhost:7000"
             storageCredentialId: "the-credentials-id"
-            maxUploadRetries: 3
-            retryDelaySeconds: 10
+            maxUploadRetries: 0
+            retryDelaySeconds: 0


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This adds a retry mechanism for when uploading artifacts or stashes to Artifactory fails. Retries are disabled by default.

Closes #98

Disclaimer: I abused of Copilot and Claude Sonnet 4 to make this PR. I am not familiar with the codebase, nor I have any relevant experience with Java. The reason why I did it anyway is because this feature is crucial for me. I truly hope the code is not so bad. And if it is, I promise no hard feelings if you just decide it's not even worth reviewing.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Tests have been added, and this was also verified in a Jenkins instance:

https://github.com/user-attachments/assets/b156687a-e60f-4572-b7ca-500afa7f578c

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
