### PR TITLE
Add option to disable direct download redirection (Proxy through Jenkins)

### DIFF
--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig.java
@@ -48,6 +48,7 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
     private String prefix;
     private int maxUploadRetries = DEFAULT_MAX_UPLOAD_RETRIES;
     private int retryDelaySeconds = DEFAULT_RETRY_DELAY_SECONDS;
+    private boolean disableDirectDownload = false;
 
     @DataBoundConstructor
     public ArtifactoryGenericArtifactConfig() {}
@@ -60,6 +61,7 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
         this.prefix = prefix;
         this.maxUploadRetries = DEFAULT_MAX_UPLOAD_RETRIES;
         this.retryDelaySeconds = DEFAULT_RETRY_DELAY_SECONDS;
+        this.disableDirectDownload = false;
     }
 
     public ArtifactoryGenericArtifactConfig(
@@ -75,6 +77,7 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
         this.prefix = prefix;
         this.maxUploadRetries = maxUploadRetries;
         this.retryDelaySeconds = retryDelaySeconds;
+        this.disableDirectDownload = false;
     }
 
     public String getStorageCredentialId() {
@@ -129,6 +132,15 @@ public class ArtifactoryGenericArtifactConfig extends AbstractDescribableImpl<Ar
     @DataBoundSetter
     public void setRetryDelaySeconds(int retryDelaySeconds) {
         this.retryDelaySeconds = Math.max(0, retryDelaySeconds); // Minimum 0 seconds (no delay)
+    }
+
+    public boolean getDisableDirectDownload() {
+        return disableDirectDownload;
+    }
+
+    @DataBoundSetter
+    public void setDisableDirectDownload(boolean disableDirectDownload) {
+        this.disableDirectDownload = disableDirectDownload;
     }
 
     public static ArtifactoryGenericArtifactConfig get() {

--- a/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryVirtualFile.java
+++ b/src/main/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryVirtualFile.java
@@ -73,6 +73,10 @@ public class ArtifactoryVirtualFile extends ArtifactoryAbstractVirtualFile {
     @CheckForNull
     @Override
     public URL toExternalURL() throws IOException {
+        ArtifactoryGenericArtifactConfig config = Utils.getArtifactConfig();
+        if (config != null && config.getDisableDirectDownload()) {
+            return null;
+        }
         return new URL(Utils.getUrl(this.key));
     }
 

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.jelly
@@ -20,6 +20,9 @@
                 <f:entry title="${%RetryDelaySeconds_title}" field="retryDelaySeconds">
                         <f:number min="0" max="300" default="5"/>
                 </f:entry>
+                <f:entry title="${%DisableDirectDownload_title}" field="disableDirectDownload">
+                        <f:checkbox/>
+                </f:entry>
                 <f:validateButton title="Validate Artifactory configuration" progress="Validate..." method="validateArtifactoryConfig"
                                   with="prefix,serverUrl,storageCredentialId,repository"/>
         </f:section>

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.properties
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/config.properties
@@ -5,3 +5,4 @@ ServerUrl_name_title=Server URL
 Prefix_title=Base Prefix (Optional)
 MaxUploadRetries_title=Max Upload Retries
 RetryDelaySeconds_title=Retry Delay (seconds)
+DisableDirectDownload_title=Disable Direct Download

--- a/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-disableDirectDownload.html
+++ b/src/main/resources/io/jenkins/plugins/artifactory_artifacts/ArtifactoryGenericArtifactConfig/help-disableDirectDownload.html
@@ -1,0 +1,15 @@
+<div>
+  <p>
+    When unchecked (default), artifact links in Jenkins redirect the browser directly to the Artifactory server.
+  </p>
+  <p>
+    When checked, Jenkins proxies all artifact downloads through itself, streaming each file from
+    Artifactory on behalf of the browser. Use this when Artifactory is on a private network not
+    reachable from users' browsers, or when you want Jenkins to be the single access point and
+    enforce its own authentication.
+  </p>
+  <p>
+    <strong>Note:</strong> with this option enabled, all download traffic passes through the Jenkins
+    controller, which may affect performance for large or frequently accessed artifacts.
+  </p>
+</div>

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryRetryConfigTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for configurable retry mechanism in ArtifactoryGenericArtifactConfig.
+ * Tests for configurable retry mechanism and download settings in ArtifactoryGenericArtifactConfig.
  */
 public class ArtifactoryRetryConfigTest {
 
@@ -69,5 +69,22 @@ public class ArtifactoryRetryConfigTest {
 
         assertThat("Config should allow zero retry count", config.getMaxUploadRetries(), equalTo(0));
         assertThat("Config should allow zero retry delay", config.getRetryDelaySeconds(), equalTo(0));
+    }
+
+    @Test
+    public void shouldDefaultDisableDirectDownloadToFalse() {
+        ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
+
+        assertThat("disableDirectDownload should default to false", config.getDisableDirectDownload(), equalTo(false));
+    }
+
+    @Test
+    public void shouldAllowEnablingDisableDirectDownload() {
+        ArtifactoryGenericArtifactConfig config = new ArtifactoryGenericArtifactConfig();
+
+        config.setDisableDirectDownload(true);
+
+        assertThat(
+                "disableDirectDownload should be settable to true", config.getDisableDirectDownload(), equalTo(true));
     }
 }

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryVirtualFileTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ArtifactoryVirtualFileTest.java
@@ -1,0 +1,53 @@
+package io.jenkins.plugins.artifactory_artifacts;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.net.URL;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+/**
+ * Tests for ArtifactoryVirtualFile.toExternalURL() behavior controlled by disableDirectDownload.
+ */
+@WithJenkins
+@WireMockTest
+public class ArtifactoryVirtualFileTest extends BaseTest {
+
+    @Test
+    public void toExternalUrlShouldReturnArtifactoryUrlWhenDisableDirectDownloadIsFalse(
+            JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        ArtifactoryGenericArtifactConfig config = configureConfig(jenkinsRule, wmRuntimeInfo.getHttpPort(), "");
+        config.setDisableDirectDownload(false);
+
+        ArtifactoryVirtualFile virtualFile =
+                new ArtifactoryVirtualFile("my-generic-repo/job/1/artifacts/file.txt", null);
+
+        URL url = virtualFile.toExternalURL();
+
+        assertThat("toExternalURL() should return a URL when disableDirectDownload is false", url, notNullValue());
+        assertThat(
+                "URL should point to the configured Artifactory server",
+                url.toString().startsWith("http://localhost:" + wmRuntimeInfo.getHttpPort()),
+                equalTo(true));
+    }
+
+    @Test
+    public void toExternalUrlShouldReturnNullWhenDisableDirectDownloadIsTrue(
+            JenkinsRule jenkinsRule, WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        ArtifactoryGenericArtifactConfig config = configureConfig(jenkinsRule, wmRuntimeInfo.getHttpPort(), "");
+        config.setDisableDirectDownload(true);
+
+        ArtifactoryVirtualFile virtualFile =
+                new ArtifactoryVirtualFile("my-generic-repo/job/1/artifacts/file.txt", null);
+
+        URL url = virtualFile.toExternalURL();
+
+        assertThat("toExternalURL() should return null when disableDirectDownload is true", url, nullValue());
+    }
+}

--- a/src/test/java/io/jenkins/plugins/artifactory_artifacts/ConfigurationAsCodeTest.java
+++ b/src/test/java/io/jenkins/plugins/artifactory_artifacts/ConfigurationAsCodeTest.java
@@ -38,5 +38,18 @@ public class ConfigurationAsCodeTest extends BaseTest {
         assertThat(config.getPrefix(), is("jenkins/"));
         assertThat(config.getMaxUploadRetries(), is(0));
         assertThat(config.getRetryDelaySeconds(), is(0));
+        assertThat(config.getDisableDirectDownload(), is(false));
+    }
+
+    @Test
+    @ConfiguredWithCode("configuration-as-code-disable-direct-download.yml")
+    public void shouldSupportConfigurationAsCodeWithDisableDirectDownload(JenkinsConfiguredWithCodeRule jenkinsRule)
+            throws Exception {
+        ArtifactoryGenericArtifactConfig config = Utils.getArtifactConfig();
+        assertThat(config.getStorageCredentialId(), is("the-credentials-id"));
+        assertThat(config.getServerUrl(), is("http://localhost:7000"));
+        assertThat(config.getRepository(), is("my-generic-repo"));
+        assertThat(config.getPrefix(), is("jenkins/"));
+        assertThat(config.getDisableDirectDownload(), is(true));
     }
 }

--- a/src/test/resources/io/jenkins/plugins/artifactory_artifacts/configuration-as-code-disable-direct-download.yml
+++ b/src/test/resources/io/jenkins/plugins/artifactory_artifacts/configuration-as-code-disable-direct-download.yml
@@ -1,0 +1,12 @@
+unclassified:
+  artifactManager:
+    artifactManagerFactories:
+      - artifactory:
+          config:
+            prefix: "jenkins/"
+            repository: "my-generic-repo"
+            serverUrl: "http://localhost:7000"
+            storageCredentialId: "the-credentials-id"
+            maxUploadRetries: 0
+            retryDelaySeconds: 0
+            disableDirectDownload: true


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This change introduces a new option to disable redirecting to Artifactory for file access and instead proxy the download through Jenkins. This is done by returning Null as the external URL of the Virtual File if the new option is enabled. This might actually partially address #147.

### Testing done

I tried to add some tests for the new option. I hope putting some of it in the RetryConfigTest class is okay.

I also ran a test instance to validate that the new option works as intended. When the option is enabled Jenkins will directly provide the artifact just like it would without the plugin. And I verified that the option can be disabled at any time, going back to the old behavior.
  
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
